### PR TITLE
Addition to sort 'modules' section alphabetically.

### DIFF
--- a/maven-plugin/src/it/sort-modules/expected_pom.xml
+++ b/maven-plugin/src/it/sort-modules/expected_pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.github.ekryd.sortpom.its</groupId>
+  <artifactId>sort-modules</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>SortPom Plugin :: ITs :: Sort modules</name>
+  <description>Test sorting plugins</description>
+  <url>no-url</url>
+  <modules>
+    <module>sort-modules-a</module>
+    <module>sort-modules-c</module>
+    <module>sort-modules-d</module>
+  </modules>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.ekryd.sortpom</groupId>
+        <artifactId>sortpom-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>sort</goal>
+            </goals>
+            <configuration>
+              <sortModules>true</sortModules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-plugin/src/it/sort-modules/invoker.properties
+++ b/maven-plugin/src/it/sort-modules/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-e clean verify

--- a/maven-plugin/src/it/sort-modules/pom.xml
+++ b/maven-plugin/src/it/sort-modules/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.github.ekryd.sortpom.its</groupId>
+  <artifactId>sort-modules</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>SortPom Plugin :: ITs :: Sort modules</name>
+  <description>Test sorting plugins</description>
+  <url>no-url</url>
+  <modules>
+    <module>sort-modules-a</module>
+    <module>sort-modules-d</module>
+    <module>sort-modules-c</module>
+  </modules>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.ekryd.sortpom</groupId>
+        <artifactId>sortpom-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>sort</goal>
+            </goals>
+            <configuration>
+              <sortModules>true</sortModules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-plugin/src/it/sort-modules/postbuild.groovy
+++ b/maven-plugin/src/it/sort-modules/postbuild.groovy
@@ -1,0 +1,13 @@
+log = new File(basedir, 'build.log')
+sorted = new File(basedir, 'pom.xml')
+expected = new File(basedir, 'expected_pom.xml')
+backup = new File(basedir, 'pom.xml.bak')
+
+assert log.exists()
+assert log.text.contains('Sorting file ' + sorted.absolutePath)
+assert log.text.contains('Saved backup of ' + sorted.absolutePath + ' to ' + backup.absolutePath)
+assert log.text.contains('Saved sorted pom file to ' + sorted.absolutePath)
+assert backup.exists()
+assert expected.text.normalize().replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.normalize().tokenize('\n'))
+
+return true

--- a/maven-plugin/src/it/sort-modules/sort-modules-a/pom.xml
+++ b/maven-plugin/src/it/sort-modules/sort-modules-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>sort-modules</artifactId>
+    <groupId>com.github.ekryd.sortpom.its</groupId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>sort-modules-a</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>SortPom Plugin :: ITs :: Sort modules submodule d</name>
+  <description>Test sorting plugins</description>
+</project>

--- a/maven-plugin/src/it/sort-modules/sort-modules-c/pom.xml
+++ b/maven-plugin/src/it/sort-modules/sort-modules-c/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>sort-modules</artifactId>
+    <groupId>com.github.ekryd.sortpom.its</groupId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>sort-modules-c</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>SortPom Plugin :: ITs :: Sort modules submodule d</name>
+  <description>Test sorting plugins</description>
+</project>

--- a/maven-plugin/src/it/sort-modules/sort-modules-d/pom.xml
+++ b/maven-plugin/src/it/sort-modules/sort-modules-d/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>sort-modules</artifactId>
+    <groupId>com.github.ekryd.sortpom.its</groupId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>sort-modules-d</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>SortPom Plugin :: ITs :: Sort modules submodule d</name>
+  <description>Test sorting plugins</description>
+</project>

--- a/maven-plugin/src/main/java/sortpom/SortMojo.java
+++ b/maven-plugin/src/main/java/sortpom/SortMojo.java
@@ -116,6 +116,12 @@ public class SortMojo extends AbstractMojo {
      */
     @Parameter(property = "sort.sortProperties", defaultValue = "false")
     private boolean sortProperties;
+    
+    /**
+     * Should the Maven pom sub modules be sorted alphabetically. 
+     */
+    @Parameter(property = "sort.sortModules", defaultValue = "false")
+    private boolean sortModules;
 
     /**
      * Set this to 'true' to bypass sortpom plugin
@@ -154,7 +160,7 @@ public class SortMojo extends AbstractMojo {
                     .setFormatting(lineSeparator, expandEmptyElements, keepBlankLines)
                     .setIndent(nrOfIndentSpace, indentBlankLines)
                     .setSortOrder(sortOrderFile, predefinedSortOrder)
-                    .setSortEntities(sortDependencies, sortPlugins, sortProperties)
+                    .setSortEntities(sortDependencies, sortPlugins, sortProperties, sortModules)
                     .setTriggers(ignoreLineSeparators)
                     .createPluginParameters();
 

--- a/maven-plugin/src/main/java/sortpom/VerifyMojo.java
+++ b/maven-plugin/src/main/java/sortpom/VerifyMojo.java
@@ -60,6 +60,12 @@ public class VerifyMojo extends AbstractMojo {
      */
     @Parameter(property = "sort.sortProperties", defaultValue = "false")
     private boolean sortProperties;
+    
+    /**
+     * Should the Maven pom sub modules be sorted alphabetically. 
+     */
+    @Parameter(property = "sort.sortModules", defaultValue = "false")
+    private boolean sortModules;
 
     /**
      * Encoding for the files.
@@ -155,7 +161,7 @@ public class VerifyMojo extends AbstractMojo {
                     .setFormatting(lineSeparator, expandEmptyElements, keepBlankLines)
                     .setIndent(nrOfIndentSpace, indentBlankLines)
                     .setSortOrder(sortOrderFile, predefinedSortOrder)
-                    .setSortEntities(sortDependencies, sortPlugins, sortProperties)
+                    .setSortEntities(sortDependencies, sortPlugins, sortProperties, sortModules)
                     .setVerifyFail(verifyFail)
                     .createPluginParameters();
 

--- a/sorter/src/main/java/sortpom/parameter/PluginParameters.java
+++ b/sorter/src/main/java/sortpom/parameter/PluginParameters.java
@@ -16,6 +16,7 @@ public class PluginParameters {
     public final DependencySortOrder sortDependencies;
     public final DependencySortOrder sortPlugins;
     public final boolean sortProperties;
+    public final boolean sortModules;
     public final boolean keepBlankLines;
     public final boolean indentBlankLines;
     public final VerifyFailType verifyFailType;
@@ -24,7 +25,7 @@ public class PluginParameters {
     PluginParameters(File pomFile, boolean createBackupFile, String backupFileExtension, String encoding,
                      LineSeparatorUtil lineSeparatorUtil, boolean expandEmptyElements, boolean keepBlankLines,
                      String indentCharacters, boolean indentBlankLines, String predefinedSortOrder, String customSortOrderFile,
-                     DependencySortOrder sortDependencies, DependencySortOrder sortPlugins, boolean sortProperties,
+                     DependencySortOrder sortDependencies, DependencySortOrder sortPlugins, boolean sortProperties, boolean sortModules,
                      VerifyFailType verifyFailType, boolean ignoreLineSeparators) {
         this.pomFile = pomFile;
         this.createBackupFile = createBackupFile;
@@ -38,6 +39,7 @@ public class PluginParameters {
         this.sortDependencies = sortDependencies;
         this.sortPlugins = sortPlugins;
         this.sortProperties = sortProperties;
+        this.sortModules = sortModules;
         this.keepBlankLines = keepBlankLines;
         this.indentBlankLines = indentBlankLines;
         this.verifyFailType = verifyFailType;

--- a/sorter/src/main/java/sortpom/parameter/PluginParametersBuilder.java
+++ b/sorter/src/main/java/sortpom/parameter/PluginParametersBuilder.java
@@ -17,6 +17,7 @@ public class PluginParametersBuilder {
     private DependencySortOrder sortDependencies;
     private DependencySortOrder sortPlugins;
     private boolean sortProperties;
+    private boolean sortModules;
     private boolean keepBlankLines;
     private VerifyFailType verifyFailType;
     private boolean ignoreLineSeparators;
@@ -66,10 +67,11 @@ public class PluginParametersBuilder {
 
     /** Sets if any additional pom file elements should be sorted */
     public PluginParametersBuilder setSortEntities(final String sortDependencies,
-                                                   final String sortPlugins, final boolean sortProperties) {
+                                                   final String sortPlugins, final boolean sortProperties, final boolean sortModules) {
         this.sortDependencies = new DependencySortOrder(sortDependencies);
         this.sortPlugins = new DependencySortOrder(sortPlugins);
         this.sortProperties = sortProperties;
+        this.sortModules = sortModules;
         return this;
     }
 
@@ -90,7 +92,7 @@ public class PluginParametersBuilder {
         return new PluginParameters(pomFile, createBackupFile, backupFileExtension,
                 encoding, lineSeparatorUtil, expandEmptyElements, keepBlankLines, indentCharacters, indentBlankLines,
                 predefinedSortOrder, customSortOrderFile,
-                sortDependencies, sortPlugins, sortProperties,
+                sortDependencies, sortPlugins, sortProperties, sortModules,
                 verifyFailType, ignoreLineSeparators);
     }
 }

--- a/sorter/src/main/java/sortpom/wrapper/ElementWrapperCreator.java
+++ b/sorter/src/main/java/sortpom/wrapper/ElementWrapperCreator.java
@@ -15,6 +15,8 @@ public class ElementWrapperCreator {
     private DependencySortOrder sortDependencies;
     private DependencySortOrder sortPlugins;
     private boolean sortProperties;
+    private boolean sortModules;
+    
     private final ElementSortOrderMap elementNameSortOrderMap;
 
 
@@ -26,6 +28,7 @@ public class ElementWrapperCreator {
         this.sortDependencies = pluginParameters.sortDependencies;
         this.sortPlugins = pluginParameters.sortPlugins;
         this.sortProperties = pluginParameters.sortProperties;
+        this.sortModules = pluginParameters.sortModules;
     }
 
     public Wrapper<Element> createWrapper(Element element) {
@@ -42,6 +45,9 @@ public class ElementWrapperCreator {
                 return pluginSortedWrapper;
             }
             return new SortedWrapper(element, elementNameSortOrderMap.getSortOrder(element));
+        }
+        if(isModuleElement(element)) {
+            return new AlphabeticalSortedWrapper(element);
         }
         if (isPropertyElement(element)) {
             return new AlphabeticalSortedWrapper(element);
@@ -74,6 +80,13 @@ public class ElementWrapperCreator {
         boolean inTheRightPlace = deepName.startsWith("/project/properties/")
                 || deepName.startsWith("/project/profiles/profile/properties/");
         return inTheRightPlace && isElementParentName(element, "properties");
+    }
+
+    private boolean isModuleElement(final Element element) {
+        if (!sortModules) {
+            return false;
+        }
+        return isElementName(element, "module") && isElementParentName(element, "modules");
     }
 
 }

--- a/sorter/src/main/java/sortpom/wrapper/ElementWrapperCreator.java
+++ b/sorter/src/main/java/sortpom/wrapper/ElementWrapperCreator.java
@@ -44,10 +44,10 @@ public class ElementWrapperCreator {
                 pluginSortedWrapper.setSortOrder(sortPlugins);
                 return pluginSortedWrapper;
             }
+            if(isModuleElement(element)) {
+                return new ModuleSortedWrapper(element, elementNameSortOrderMap.getSortOrder(element));
+            }
             return new SortedWrapper(element, elementNameSortOrderMap.getSortOrder(element));
-        }
-        if(isModuleElement(element)) {
-            return new AlphabeticalSortedWrapper(element);
         }
         if (isPropertyElement(element)) {
             return new AlphabeticalSortedWrapper(element);

--- a/sorter/src/main/java/sortpom/wrapper/content/ModuleSortedWrapper.java
+++ b/sorter/src/main/java/sortpom/wrapper/content/ModuleSortedWrapper.java
@@ -1,0 +1,56 @@
+package sortpom.wrapper.content;
+
+import org.jdom.Content;
+import org.jdom.Element;
+import sortpom.parameter.DependencySortOrder;
+
+import java.util.List;
+
+/**
+ * A wrapper that contains a module element. The module is sorted alphabetically.
+ *
+ * @author msbg
+ */
+public class ModuleSortedWrapper extends SortedWrapper {
+    private final String text;
+    /**
+     * Instantiates a new child element sorted wrapper with a module element.
+     *
+     * @param element   the element
+     * @param sortOrder the sort order
+     */
+    public ModuleSortedWrapper(final Element element, final int sortOrder) {
+        super(element, sortOrder);
+        text = element.getTextTrim();
+    }
+    
+
+    @Override
+    public boolean isBefore(final Wrapper<? extends Content> wrapper) {
+        if (wrapper instanceof ModuleSortedWrapper) {
+            return isBeforeDependencySortedWrapper((ModuleSortedWrapper) wrapper);
+        }
+        return super.isBefore(wrapper);
+    }
+
+    private boolean isBeforeDependencySortedWrapper(final ModuleSortedWrapper wrapper) {
+        // Sort order rules before sorting alphabetic contents.
+        if (wrapper.getSortOrder() != getSortOrder()) {
+            return super.isBefore(wrapper);
+        }
+
+        return isBeforeAlphabeticalTextSortedWrapper(wrapper);
+    }
+
+    private boolean isBeforeAlphabeticalTextSortedWrapper(ModuleSortedWrapper wrapper) {
+        return wrapper.text.compareTo(text) >= 0;
+    }
+
+    @Override
+    public String toString() {
+        return "ModuleSortedWrapper{content=" +
+                getContent() +
+                '}';
+    }
+
+}

--- a/sorter/src/main/java/sortpom/wrapper/content/ModuleSortedWrapper.java
+++ b/sorter/src/main/java/sortpom/wrapper/content/ModuleSortedWrapper.java
@@ -28,18 +28,9 @@ public class ModuleSortedWrapper extends SortedWrapper {
     @Override
     public boolean isBefore(final Wrapper<? extends Content> wrapper) {
         if (wrapper instanceof ModuleSortedWrapper) {
-            return isBeforeDependencySortedWrapper((ModuleSortedWrapper) wrapper);
+            return isBeforeAlphabeticalTextSortedWrapper((ModuleSortedWrapper) wrapper);
         }
         return super.isBefore(wrapper);
-    }
-
-    private boolean isBeforeDependencySortedWrapper(final ModuleSortedWrapper wrapper) {
-        // Sort order rules before sorting alphabetic contents.
-        if (wrapper.getSortOrder() != getSortOrder()) {
-            return super.isBefore(wrapper);
-        }
-
-        return isBeforeAlphabeticalTextSortedWrapper(wrapper);
     }
 
     private boolean isBeforeAlphabeticalTextSortedWrapper(ModuleSortedWrapper wrapper) {

--- a/sorter/src/test/java/sortpom/sort/SortModulesTest.java
+++ b/sorter/src/test/java/sortpom/sort/SortModulesTest.java
@@ -15,4 +15,13 @@ public class SortModulesTest {
                 .lineSeparator("\n")
                 .testFiles("/SortModules_input.xml", "/SortModules_expected.xml");
     }
+    @Test
+    public final void sortingOfPomFileWithSubmodulesNotEnabled() throws Exception {
+        SortPomImplUtil.create()
+                .sortProperties()
+                .sortPlugins("true")
+                .sortDependencies("true")
+                .lineSeparator("\n")
+                .testFiles("/SortModules_input.xml", "/SortModules_expected_notsorted.xml");
+    }
 }

--- a/sorter/src/test/java/sortpom/sort/SortModulesTest.java
+++ b/sorter/src/test/java/sortpom/sort/SortModulesTest.java
@@ -15,6 +15,17 @@ public class SortModulesTest {
                 .testFiles("/SortModules_input.xml", "/SortModules_expected.xml");
     }
     @Test
+    public final void sortingOfPomFileWithSubmodulesAndExtraElementsShouldWork() throws Exception {
+        SortPomImplUtil.create()
+                .defaultOrderFileName("sortOrderFiles/extra_dummy_tags.xml")
+                .sortProperties()
+                .sortPlugins("true")
+                .sortModules()
+                .sortDependencies("true")
+                .lineSeparator("\n")
+                .testFiles("/SortModules_input_extra_elements.xml", "/SortModules_expected_extra_elements.xml");
+    }
+    @Test
     public final void sortingOfPomFileWithSubmodulesNotEnabled() throws Exception {
         SortPomImplUtil.create()
                 .sortProperties()

--- a/sorter/src/test/java/sortpom/sort/SortModulesTest.java
+++ b/sorter/src/test/java/sortpom/sort/SortModulesTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 import sortpom.util.SortPomImplUtil;
 
 public class SortModulesTest {
-    
     @Test
     public final void sortingOfPomFileWithSubmodulesShouldWork() throws Exception {
         SortPomImplUtil.create()

--- a/sorter/src/test/java/sortpom/sort/SortModulesTest.java
+++ b/sorter/src/test/java/sortpom/sort/SortModulesTest.java
@@ -1,0 +1,18 @@
+package sortpom.sort;
+
+import org.junit.Test;
+import sortpom.util.SortPomImplUtil;
+
+public class SortModulesTest {
+    
+    @Test
+    public final void sortingOfPomFileWithSubmodulesShouldWork() throws Exception {
+        SortPomImplUtil.create()
+                .sortProperties()
+                .sortPlugins("true")
+                .sortModules()
+                .sortDependencies("true")
+                .lineSeparator("\n")
+                .testFiles("/SortModules_input.xml", "/SortModules_expected.xml");
+    }
+}

--- a/sorter/src/test/java/sortpom/util/SortPomImplUtil.java
+++ b/sorter/src/test/java/sortpom/util/SortPomImplUtil.java
@@ -18,6 +18,7 @@ public class SortPomImplUtil {
     private String sortDependencies = "";
     private String sortPlugins = "";
     private boolean sortProperties = false;
+    private boolean sortModules = false;
     private String predefinedSortOrder = "";
     private String lineSeparator = "\r\n";
     private String testPomFileName = "src/test/resources/testpom.xml";
@@ -145,6 +146,11 @@ public class SortPomImplUtil {
         return this;
     }
 
+    public SortPomImplUtil sortModules() {
+        sortModules = true;
+        return this;
+    }
+
     public SortPomImplUtil defaultOrderFileName(String defaultOrderFileName) {
         this.defaultOrderFileName = defaultOrderFileName;
         return this;
@@ -198,7 +204,7 @@ public class SortPomImplUtil {
                 .setEncoding(encoding)
                 .setFormatting(lineSeparator, true, keepBlankLines)
                 .setIndent(nrOfIndentSpace, indentBLankLines)
-                .setSortEntities(sortDependencies, sortPlugins, sortProperties)
+                .setSortEntities(sortDependencies, sortPlugins, sortProperties, sortModules)
                 .setSortOrder(defaultOrderFileName, predefinedSortOrder)
                 .setVerifyFail(verifyFail)
                 .setTriggers(ignoreLineSeparators)

--- a/sorter/src/test/java/sortpom/util/XmlProcessorTestUtil.java
+++ b/sorter/src/test/java/sortpom/util/XmlProcessorTestUtil.java
@@ -82,7 +82,7 @@ public class XmlProcessorTestUtil {
                 .setFormatting(lineSeparator, expandEmptyElements, keepBlankLines)
                 .setIndent(2, indentBlankLines)
                 .setSortOrder(predefinedSortOrder + ".xml", null)
-                .setSortEntities("", "", false).createPluginParameters();
+                .setSortEntities("", "", false, false).createPluginParameters();
         final String xml = IOUtils.toString(new FileInputStream(inputFileName), UTF_8);
 
         final FileUtil fileUtil = new FileUtil();

--- a/sorter/src/test/java/sortpom/wrapper/ElementToStringTest.java
+++ b/sorter/src/test/java/sortpom/wrapper/ElementToStringTest.java
@@ -36,7 +36,7 @@ public class ElementToStringTest {
                 .setFormatting("\r\n", true, true)
                 .setIndent(2, false)
                 .setSortOrder("default_0_4_0.xml", null)
-                .setSortEntities("scope,groupId,artifactId", "groupId,artifactId", true, false).createPluginParameters();
+                .setSortEntities("scope,groupId,artifactId", "groupId,artifactId", true, true).createPluginParameters();
 
         FileUtil fileUtil = new FileUtil();
         fileUtil.setup(pluginParameters);

--- a/sorter/src/test/java/sortpom/wrapper/ElementToStringTest.java
+++ b/sorter/src/test/java/sortpom/wrapper/ElementToStringTest.java
@@ -36,7 +36,7 @@ public class ElementToStringTest {
                 .setFormatting("\r\n", true, true)
                 .setIndent(2, false)
                 .setSortOrder("default_0_4_0.xml", null)
-                .setSortEntities("scope,groupId,artifactId", "groupId,artifactId", true).createPluginParameters();
+                .setSortEntities("scope,groupId,artifactId", "groupId,artifactId", true, false).createPluginParameters();
 
         FileUtil fileUtil = new FileUtil();
         fileUtil.setup(pluginParameters);

--- a/sorter/src/test/resources/Real1_expected.xml
+++ b/sorter/src/test/resources/Real1_expected.xml
@@ -29,6 +29,9 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <modules>
+    <module>a</module>
+  </modules>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compileSource>1.6</compileSource>

--- a/sorter/src/test/resources/Real1_expected_keepBlankLines.xml
+++ b/sorter/src/test/resources/Real1_expected_keepBlankLines.xml
@@ -34,6 +34,10 @@
     </dependency>
   </dependencies>
 
+  <modules>
+    <module>a</module>
+  </modules>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compileSource>1.6</compileSource>

--- a/sorter/src/test/resources/Real1_expected_keepBlankLines_indented.xml
+++ b/sorter/src/test/resources/Real1_expected_keepBlankLines_indented.xml
@@ -34,6 +34,10 @@
     </dependency>
   </dependencies>
   
+  <modules>
+    <module>a</module>
+  </modules>
+  
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compileSource>1.6</compileSource>

--- a/sorter/src/test/resources/Real1_expected_toString.txt
+++ b/sorter/src/test/resources/Real1_expected_toString.txt
@@ -59,6 +59,20 @@ HierarchyWrapper{
   HierarchyWrapper{
     otherContentList=
     UnsortedWrapper{content=[NewLine]}
+    elementContent=SortedWrapper{element=[Element: <modules [Namespace: http://maven.apache.org/POM/4.0.0]/>]}
+    children=
+    HierarchyWrapper{
+      elementContent=ModuleSortedWrapper{content=[Element: <module [Namespace: http://maven.apache.org/POM/4.0.0]/>]}
+      children=
+      HierarchyWrapper{
+        otherContentList=
+        UnsortedWrapper{content=[Text: a]}
+        }
+      }
+    }
+  HierarchyWrapper{
+    otherContentList=
+    UnsortedWrapper{content=[NewLine]}
     elementContent=SortedWrapper{element=[Element: <build [Namespace: http://maven.apache.org/POM/4.0.0]/>]}
     children=
     HierarchyWrapper{

--- a/sorter/src/test/resources/Real1_input.xml
+++ b/sorter/src/test/resources/Real1_input.xml
@@ -13,6 +13,10 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<description>Sorts the pom file</description>
 
+	<modules>
+		<module>a</module>
+	</modules>
+	
 	<build>
 		<defaultGoal>verify</defaultGoal>
 

--- a/sorter/src/test/resources/SortModules_expected.xml
+++ b/sorter/src/test/resources/SortModules_expected.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- Thank you Christian Haelg  -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>sortpom</groupId>
+  <artifactId>sortpom</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <modules>
+    <module>a</module>
+    <module>b</module>
+    <module>c</module>
+    <module>d</module>
+  </modules>
+</project>

--- a/sorter/src/test/resources/SortModules_expected_extra_elements.xml
+++ b/sorter/src/test/resources/SortModules_expected_extra_elements.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- Thank you Christian Haelg  -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>sortpom</groupId>
+  <artifactId>sortpom</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <modules>
+    <module>a</module>
+    <module>b</module>
+    <module>c</module>
+    <module>d</module>
+    <unknown extra="newExtra"></unknown>
+  </modules>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/sorter/src/test/resources/SortModules_expected_notsorted.xml
+++ b/sorter/src/test/resources/SortModules_expected_notsorted.xml
@@ -8,8 +8,8 @@
   <modules>
     <module>a</module>
     <module>b</module>
-    <module>c</module>
     <module>d</module>
+    <module>c</module>
   </modules>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/sorter/src/test/resources/SortModules_input.xml
+++ b/sorter/src/test/resources/SortModules_input.xml
@@ -5,6 +5,9 @@
   <groupId>sortpom</groupId>
   <artifactId>sortpom</artifactId>
   <version>1.0.0-SNAPSHOT</version>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <modules>
     <module>a</module>
     <module>b</module>

--- a/sorter/src/test/resources/SortModules_input.xml
+++ b/sorter/src/test/resources/SortModules_input.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- Thank you Christian Haelg  -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>sortpom</groupId>
+  <artifactId>sortpom</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <modules>
+    <module>a</module>
+    <module>b</module>
+    <module>d</module>
+    <module>c</module>
+  </modules>
+</project>

--- a/sorter/src/test/resources/SortModules_input_extra_elements.xml
+++ b/sorter/src/test/resources/SortModules_input_extra_elements.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- Thank you Christian Haelg  -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>sortpom</groupId>
+  <artifactId>sortpom</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <modules>
+    <unknown extra="newExtra"></unknown>
+    <module>a</module>
+    <module>b</module>
+    <module>d</module>
+    <module>c</module>
+  </modules>
+</project>

--- a/sorter/src/test/resources/sortOrderFiles/extra_dummy_tags.xml
+++ b/sorter/src/test/resources/sortOrderFiles/extra_dummy_tags.xml
@@ -18,6 +18,7 @@
   </prerequisites>
   <modules>
     <module>module</module>
+    <unknown/>
   </modules>
   <properties></properties>
   <dependencyManagement>


### PR DESCRIPTION
Hi, 
Many thanks for creating this plugin, greatly appreciated. One small extra feature I would like is to be able to sort the 'modules' section of a pom alphabetically(which is very handy in large multi-module builds). I've put together an update here that will optionally enable this. Any thoughts/updates appreciated.

Regards,

- monica