### PR TITLE
added option "keepTimestamp"

### DIFF
--- a/maven-plugin/src/it/mojo-description/expected.log
+++ b/maven-plugin/src/it/mojo-description/expected.log
@@ -71,6 +71,11 @@ sortpom:sort
       Should blank lines in the pom-file be preserved. A maximum of one line is
       preserved between each tag.
 
+    keepTimestamp (Default: false)
+      User property: sort.keepTimestamp
+      Whether to keep the file timestamps of old POM file when creating new POM
+      file or backup file.
+
     lineSeparator (Default: ${line.separator})
       User property: sort.lineSeparator
       Line separator for sorted pom. Can be either \n, \r or \r\n

--- a/maven-plugin/src/main/java/sortpom/SortMojo.java
+++ b/maven-plugin/src/main/java/sortpom/SortMojo.java
@@ -18,6 +18,12 @@ import sortpom.parameter.PluginParameters;
 public class SortMojo extends AbstractParentMojo {
 
     /**
+     * Whether to keep the file timestamps of old POM file when creating new POM file or backup file.
+     */
+    @Parameter(property = "sort.keepTimestamp", defaultValue = "false")
+    boolean keepTimestamp;
+
+    /**
      * Ignore line separators when comparing current POM with sorted one
      */
     @Parameter(property = "sort.ignoreLineSeparators", defaultValue = "true")
@@ -34,6 +40,7 @@ public class SortMojo extends AbstractParentMojo {
                     .setSortOrder(sortOrderFile, predefinedSortOrder)
                     .setSortEntities(sortDependencies, sortPlugins, sortProperties, sortModules)
                     .setTriggers(ignoreLineSeparators)
+                    .setKeepTimestamp(keepTimestamp)
                     .build();
 
             sortPomImpl.setup(new MavenLogger(getLog()), pluginParameters);

--- a/maven-plugin/src/test/java/sortpom/sort/SortMojoParametersTest.java
+++ b/maven-plugin/src/test/java/sortpom/sort/SortMojoParametersTest.java
@@ -53,6 +53,11 @@ public class SortMojoParametersTest {
     }
 
     @Test
+    public void keepTimestampParameter() throws Exception {
+    	testParameterMoveFromMojoToRestOfApplicationForBoolean("keepTimestamp", sortPomImpl);
+    }
+    
+    @Test
     public void backupFileExtensionParameter() throws Exception {
         testParameterMoveFromMojoToRestOfApplication("backupFileExtension", ".gurka", sortPomImpl, fileUtil);
     }

--- a/sorter/src/main/java/sortpom/SortPomImpl.java
+++ b/sorter/src/main/java/sortpom/SortPomImpl.java
@@ -39,6 +39,7 @@ public class SortPomImpl {
     private String backupFileExtension;
     private VerifyFailType verifyFailType;
     private boolean ignoreLineSeparators;
+    private boolean keepTimestamp;    
     private String violationFilename;
 
     /**
@@ -66,6 +67,7 @@ public class SortPomImpl {
         backupFileExtension = pluginParameters.backupFileExtension;
         verifyFailType = pluginParameters.verifyFailType;
         ignoreLineSeparators = pluginParameters.ignoreLineSeparators;
+        keepTimestamp = pluginParameters.keepTimestamp;
         violationFilename = pluginParameters.violationFilename;
         warnAboutDeprecatedArguments(log, pluginParameters);
     }
@@ -99,6 +101,9 @@ public class SortPomImpl {
         }
         createBackupFile();
         saveSortedPomFile(sortedXml);
+        if (keepTimestamp) {
+        	log.info("File timestamps are kept");
+        }
     }
 
     /**

--- a/sorter/src/main/java/sortpom/parameter/PluginParameters.java
+++ b/sorter/src/main/java/sortpom/parameter/PluginParameters.java
@@ -22,12 +22,13 @@ public class PluginParameters {
     public final boolean indentBlankLines;
     public final VerifyFailType verifyFailType;
     public final boolean ignoreLineSeparators;
+    public final boolean keepTimestamp;
 
     private PluginParameters(File pomFile, boolean createBackupFile, String backupFileExtension, String violationFilename, String encoding,
                              LineSeparatorUtil lineSeparatorUtil, boolean expandEmptyElements, boolean keepBlankLines,
                              String indentCharacters, boolean indentBlankLines, String predefinedSortOrder, String customSortOrderFile,
                              DependencySortOrder sortDependencies, DependencySortOrder sortPlugins, boolean sortProperties, boolean sortModules,
-                             VerifyFailType verifyFailType, boolean ignoreLineSeparators) {
+                             VerifyFailType verifyFailType, boolean ignoreLineSeparators, boolean keepTimestamp) {
         this.pomFile = pomFile;
         this.createBackupFile = createBackupFile;
         this.backupFileExtension = backupFileExtension;
@@ -46,6 +47,7 @@ public class PluginParameters {
         this.indentBlankLines = indentBlankLines;
         this.verifyFailType = verifyFailType;
         this.ignoreLineSeparators = ignoreLineSeparators;
+        this.keepTimestamp = keepTimestamp;
     }
 
     /** Instantiate builder */
@@ -73,6 +75,7 @@ public class PluginParameters {
         private boolean keepBlankLines;
         private VerifyFailType verifyFailType;
         private boolean ignoreLineSeparators;
+        private boolean keepTimestamp;    
 
         private Builder() {
         }
@@ -143,13 +146,18 @@ public class PluginParameters {
             return this;
         }
 
+        public Builder setKeepTimestamp(boolean keepTimestamp) {
+        	this.keepTimestamp = keepTimestamp;
+        	return this;
+        }
+        
         /** Build the PluginParameters instance */
         public PluginParameters build() {
             return new PluginParameters(pomFile, createBackupFile, backupFileExtension, violationFilename,
                     encoding, lineSeparatorUtil, expandEmptyElements, keepBlankLines, indentCharacters, indentBlankLines,
                     predefinedSortOrder, customSortOrderFile,
                     sortDependencies, sortPlugins, sortProperties, sortModules,
-                    verifyFailType, ignoreLineSeparators);
+                    verifyFailType, ignoreLineSeparators, keepTimestamp);
         }
     }
 

--- a/sorter/src/test/java/sortpom/parameter/KeepTimestampParameterTest.java
+++ b/sorter/src/test/java/sortpom/parameter/KeepTimestampParameterTest.java
@@ -1,0 +1,28 @@
+package sortpom.parameter;
+
+import org.junit.Test;
+
+import sortpom.util.SortPomImplUtil;
+
+public class KeepTimestampParameterTest {
+
+    @Test
+    public final void whenKeepTimestampNotSetTimestampsShouldDiffer() throws Exception {
+        SortPomImplUtil.create()
+            .defaultOrderFileName("difforder/differentOrder.xml")
+            .lineSeparator("\n")
+            .keepTimestamp(false)
+            .testFilesWithTimestamp("/full_unsorted_input.xml", "/sortOrderFiles/sorted_differentOrder.xml");
+    }
+
+
+    @Test
+    public final void whenKeepTimestampIsSetTimestampsShouldRemain() throws Exception {
+    	SortPomImplUtil.create()
+	    	.defaultOrderFileName("difforder/differentOrder.xml")
+	    	.lineSeparator("\n")
+	    	.keepTimestamp(true)
+	    	.testFilesWithTimestamp("/full_unsorted_input.xml", "/sortOrderFiles/sorted_differentOrder.xml");
+    }
+    
+}

--- a/sorter/src/test/java/sortpom/util/SortPomImplUtil.java
+++ b/sorter/src/test/java/sortpom/util/SortPomImplUtil.java
@@ -27,6 +27,7 @@ public class SortPomImplUtil {
     private boolean keepBlankLines = false;
     private boolean ignoreLineSeparators = true;
     private boolean indentBLankLines = false;
+    private boolean keepTimestamp = false;
     private String verifyFail = "SORT";
     private String encoding = TestHandler.UTF_8;
     private File testpom;
@@ -52,6 +53,13 @@ public class SortPomImplUtil {
         testHandler = new TestHandler(inputResourceFileName, expectedResourceFileName, getPluginParameters());
         testHandler.performTest();
         return testHandler.getInfoLogger();
+    }
+
+    public void testFilesWithTimestamp(final String inputResourceFileName, final String expectedResourceFileName)
+            throws Exception {
+        setup();
+        testHandler = new TestHandler(inputResourceFileName, expectedResourceFileName, getPluginParameters());
+        testHandler.performTestOfTimestamps();
     }
 
     public void testNoSorting(final String inputResourceFileName)
@@ -181,6 +189,11 @@ public class SortPomImplUtil {
         return this;
     }
 
+    public SortPomImplUtil keepTimestamp(boolean keepTimestamp) {
+    	this.keepTimestamp = keepTimestamp;
+    	return this;
+    }
+    
     public SortPomImplUtil verifyFail(String verifyFail) {
         this.verifyFail = verifyFail;
         return this;
@@ -222,6 +235,7 @@ public class SortPomImplUtil {
                 .setSortOrder(defaultOrderFileName, predefinedSortOrder)
                 .setVerifyFail(verifyFail)
                 .setTriggers(ignoreLineSeparators)
+                .setKeepTimestamp(keepTimestamp)
                 .build();
     }
 

--- a/sorter/src/test/java/sortpom/util/TestHandler.java
+++ b/sorter/src/test/java/sortpom/util/TestHandler.java
@@ -172,6 +172,28 @@ class TestHandler {
         }
     }
 
+    void performTestOfTimestamps() throws Exception {
+        try {
+            removeOldTemporaryFiles();
+
+            FileUtils.copyFile(new File("src/test/resources/" + inputResourceFileName), testpom);
+            long pomTimestamp = testpom.lastModified();
+            performSorting();
+            
+            if (pluginParameters.keepTimestamp) {
+            	assertTrue(testpom.lastModified() == pomTimestamp);
+            	assertTrue(backupFile.lastModified() == pomTimestamp);
+            }
+            else {
+            	assertTrue(testpom.lastModified() > pomTimestamp);
+            	assertTrue(backupFile.lastModified() > pomTimestamp);
+            }
+            
+        } finally {
+            cleanupAfterTest();
+        }
+    }
+    
     private void performVerifyWithSort() {
         SortPomImpl sortPomImpl = new SortPomImpl();
         sortPomImpl.setup(


### PR DESCRIPTION
Adds a new Mojo option "keepTimestamp" that will (when set to "true") preserve file timestamp of original POM file for newly written POM and backup files. Default setting is "false", so behaviour will not change.

When the timestamp of POM is changed during the build, this could potentially interact with other tools that rely on stable file date. For instance, we use POM templating, i.e. the POM is generated from a POM template before the build starts, and takes file timestamps into account in order to decide whether templating is required or not. When Maven build runs and the sortpom plugin changes timestamp of the POM template file, next time the POM will be re-generated from the template even though there are no functional changes. The proposed change fixes this kind of issues.