### PR TITLE
Added tests to keep-timestamp feature

### DIFF
--- a/maven-plugin/src/it/default-configuration/postbuild.groovy
+++ b/maven-plugin/src/it/default-configuration/postbuild.groovy
@@ -27,6 +27,6 @@ assert !log.text.contains('sortDependencies =')
 assert !log.text.contains('sortPlugins =')
 
 assert backup.exists()
-assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.tokenize('\n'))
+assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.replaceAll('\r','').tokenize('\n'))
 
 return true

--- a/maven-plugin/src/it/default-configuration/postbuild.groovy
+++ b/maven-plugin/src/it/default-configuration/postbuild.groovy
@@ -20,11 +20,13 @@ assert log.text.contains('keepBlankLines = false')
 assert log.text.contains('nrOfIndentSpace = 2')
 assert log.text.contains('sortProperties = false')
 assert log.text.contains('skip = false')
+assert log.text.contains('keepTimestamp = false')
 
 assert !log.text.contains('predefinedSortOrder =')
 assert !log.text.contains('sortOrderFile =')
 assert !log.text.contains('sortDependencies =')
 assert !log.text.contains('sortPlugins =')
+assert !log.text.contains('File timestamps are kept')
 
 assert backup.exists()
 assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.replaceAll('\r','').tokenize('\n'))

--- a/maven-plugin/src/it/four-spaces-indent/postbuild.groovy
+++ b/maven-plugin/src/it/four-spaces-indent/postbuild.groovy
@@ -8,6 +8,6 @@ assert log.text.contains('Sorting file ' + sorted.absolutePath)
 assert log.text.contains('Saved backup of ' + sorted.absolutePath + ' to ' + backup.absolutePath)
 assert log.text.contains('Saved sorted pom file to ' + sorted.absolutePath)
 assert backup.exists()
-assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.tokenize('\n'))
+assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.replaceAll('\r','').tokenize('\n'))
 
 return true

--- a/maven-plugin/src/it/keep-timestamp/invoker.properties
+++ b/maven-plugin/src/it/keep-timestamp/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-X clean verify

--- a/maven-plugin/src/it/keep-timestamp/pom.xml
+++ b/maven-plugin/src/it/keep-timestamp/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <name>SortPom Plugin :: ITs :: Default configuration</name>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>default-configuration</artifactId>
+  <groupId>com.github.ekryd.sortpom.its</groupId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <description>Test default parameters of the plugin</description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+     </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.ekryd.sortpom</groupId>
+        <artifactId>sortpom-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>sort</goal>
+            </goals>
+            <configuration>
+              <keepTimestamp>true</keepTimestamp>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <url>no-url</url>
+</project>

--- a/maven-plugin/src/it/keep-timestamp/postbuild.groovy
+++ b/maven-plugin/src/it/keep-timestamp/postbuild.groovy
@@ -1,0 +1,17 @@
+log = new File(basedir, 'build.log')
+sorted = new File(basedir, 'pom.xml')
+backup = new File(basedir, 'pom.xml.bak')
+timestampFile = new File(basedir, 'pom-timestamp')
+
+assert log.exists()
+assert log.text.contains('Sorting file ' + sorted.absolutePath)
+assert log.text.contains('Saved backup of ' + sorted.absolutePath + ' to ' + backup.absolutePath)
+assert log.text.contains('Saved sorted pom file to ' + sorted.absolutePath)
+assert log.text.contains('keepTimestamp = true')
+assert log.text.contains('File timestamps are kept')
+
+timestamp = timestampFile.getText('UTF-8') as Long
+assert sorted.lastModified() == timestamp
+assert backup.lastModified() > timestamp
+
+return true

--- a/maven-plugin/src/it/keep-timestamp/prebuild.groovy
+++ b/maven-plugin/src/it/keep-timestamp/prebuild.groovy
@@ -1,0 +1,7 @@
+original = new File(basedir, 'pom.xml')
+modified = original.lastModified()
+
+timestampFile = new File(basedir, 'pom-timestamp')
+timestampFile.write(modified as String)
+
+return true

--- a/maven-plugin/src/it/mojo-description/postbuild.groovy
+++ b/maven-plugin/src/it/mojo-description/postbuild.groovy
@@ -2,6 +2,6 @@ log = new File(basedir, 'build.log')
 expected_log = new File(basedir, 'expected.log')
 
 assert log.exists()
-assert log.text.contains(expected_log.text.replaceAll('@pom.version@', projectversion))
+assert log.text.replaceAll('\r','').contains(expected_log.text.replaceAll('@pom.version@', projectversion).replaceAll('\r',''))
 
 return true

--- a/maven-plugin/src/it/no-backup/postbuild.groovy
+++ b/maven-plugin/src/it/no-backup/postbuild.groovy
@@ -8,6 +8,6 @@ assert log.text.contains('Sorting file ' + sorted.absolutePath)
 assert !log.text.contains('Saved backup of ' + sorted.absolutePath + ' to ' + backup.absolutePath)
 assert log.text.contains('Saved sorted pom file to ' + sorted.absolutePath)
 assert !backup.exists()
-assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.tokenize('\n'))
+assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.replaceAll('\r','').tokenize('\n'))
 
 return true

--- a/maven-plugin/src/it/sort-dependencies/postbuild.groovy
+++ b/maven-plugin/src/it/sort-dependencies/postbuild.groovy
@@ -8,6 +8,6 @@ assert log.text.contains('Sorting file ' + sorted.absolutePath)
 assert log.text.contains('Saved backup of ' + sorted.absolutePath + ' to ' + backup.absolutePath)
 assert log.text.contains('Saved sorted pom file to ' + sorted.absolutePath)
 assert backup.exists()
-assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.tokenize('\n'))
+assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.replaceAll('\r','').tokenize('\n'))
 
 return true

--- a/maven-plugin/src/it/sort-plugins/postbuild.groovy
+++ b/maven-plugin/src/it/sort-plugins/postbuild.groovy
@@ -8,6 +8,6 @@ assert log.text.contains('Sorting file ' + sorted.absolutePath)
 assert log.text.contains('Saved backup of ' + sorted.absolutePath + ' to ' + backup.absolutePath)
 assert log.text.contains('Saved sorted pom file to ' + sorted.absolutePath)
 assert backup.exists()
-assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.tokenize('\n'))
+assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.replaceAll('\r','').tokenize('\n'))
 
 return true

--- a/maven-plugin/src/it/sort-properties/postbuild.groovy
+++ b/maven-plugin/src/it/sort-properties/postbuild.groovy
@@ -8,6 +8,6 @@ assert log.text.contains('Sorting file ' + sorted.absolutePath)
 assert log.text.contains('Saved backup of ' + sorted.absolutePath + ' to ' + backup.absolutePath)
 assert log.text.contains('Saved sorted pom file to ' + sorted.absolutePath)
 assert backup.exists()
-assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.tokenize('\n'))
+assert expected.text.replaceAll('@pom.version@', projectversion).tokenize('\n').equals(sorted.text.replaceAll('\r','').tokenize('\n'))
 
 return true

--- a/maven-plugin/src/it/violation-file/postbuild.groovy
+++ b/maven-plugin/src/it/violation-file/postbuild.groovy
@@ -9,6 +9,6 @@ assert log.text.contains('[WARNING] The xml element <modelVersion> should be pla
 assert log.text.contains('[INFO] Saving violation report to ' + violationFile.absolutePath)
 assert log.text.contains('[WARNING] The file ' + sorted.absolutePath + ' is not sorted')
 
-assert expected_violationFile.text.replaceAll('@POM_PATH@', sorted.absolutePath).tokenize('\n').equals(violationFile.text.tokenize('\n'))
+assert expected_violationFile.text.replaceAll('@POM_PATH@', sorted.absolutePath).tokenize('\n').equals(violationFile.text.replaceAll('\r','').replaceAll('\\\\','').tokenize('\n'))
 
 return true

--- a/sorter/src/main/java/sortpom/util/FileAttributeUtil.java
+++ b/sorter/src/main/java/sortpom/util/FileAttributeUtil.java
@@ -1,0 +1,39 @@
+package sortpom.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.FileTime;
+
+/**
+ * Utility class that encapsulates methods dealing with file attributes (in
+ * particular, timestamps). Moving this functionality into separate class allows
+ * for easier testing.
+ */
+public class FileAttributeUtil {
+
+	/**
+	 * Retrieves the timestamp of last modification of given file.
+	 * 
+	 * @param file The file to be examined
+	 * @return Timestamp (in millis) of file's last modification
+	 */
+	public long getLastModifiedTimestamp(File file) {
+		return file.lastModified();
+	}
+
+	/**
+	 * Sets the access dates (creation, last modification, last access) for the
+	 * given file all to the same provided value.
+	 * 
+	 * @param file   The file to set the dates for
+	 * @param millis The value for the access dates
+	 * @throws IOException If any I/O error occurs
+	 */
+	public void setTimestamps(File file, long millis) throws IOException {
+		BasicFileAttributeView attributes = Files.getFileAttributeView(file.toPath(), BasicFileAttributeView.class);
+		FileTime time = FileTime.fromMillis(millis);
+		attributes.setTimes(time, time, time);
+	}
+}

--- a/sorter/src/main/java/sortpom/util/FileUtil.java
+++ b/sorter/src/main/java/sortpom/util/FileUtil.java
@@ -7,9 +7,6 @@ import sortpom.parameter.PluginParameters;
 import java.io.*;
 import java.net.URL;
 import java.nio.charset.UnsupportedCharsetException;
-import java.nio.file.Files;
-import java.nio.file.attribute.BasicFileAttributeView;
-import java.nio.file.attribute.FileTime;
 import java.util.Optional;
 
 /**
@@ -30,6 +27,8 @@ public class FileUtil {
     private String violationFilename;
     private long timestamp;
     private boolean keepTimestamp;
+
+    private FileAttributeUtil fileAttrUtils = new FileAttributeUtil();
 
     /** Initializes the class with sortpom parameters. */
     public void setup(PluginParameters parameters) {
@@ -90,9 +89,9 @@ public class FileUtil {
 
     private void savePomfileTimestamp() {
         if (keepTimestamp) {
-            timestamp = pomFile.lastModified();
+            timestamp = fileAttrUtils.getLastModifiedTimestamp(pomFile); 
             if (timestamp == 0) {
-                throw new FailureException("Cound not save the timestamp of the pom file: " + pomFile.getAbsolutePath());
+                throw new FailureException("Cound not retrieve the timestamp of the pom file: " + pomFile.getAbsolutePath());
             }
         }
     }
@@ -124,10 +123,8 @@ public class FileUtil {
     private void setPomfileTimestamp() {
         // when requested, keep the original's file timestamps for the created files
         if (keepTimestamp) {
-            BasicFileAttributeView attributes = Files.getFileAttributeView(pomFile.toPath(), BasicFileAttributeView.class);
-            FileTime time = FileTime.fromMillis(timestamp);
             try {
-                attributes.setTimes(time, time, time);
+                fileAttrUtils.setTimestamps(pomFile, timestamp);
             } catch (IOException e) {
                 throw new FailureException("Could not change timestamp of new pom file: " + pomFile.getAbsolutePath(), e);
             }


### PR DESCRIPTION
Added some unit test and an integration test as requested.

For the integration test, I did not found a way to pass state (the timestamp) from prebuild to postbuild code, so I dump it into a file. If there's a better way, let me know.

Please note, I was not able to successfully run the IT under Windows due to line ending problems. Committed files for expected POMs do have LF, but created POMs have CR/LF, so the postbuild comparisons fail. I know that Git can be configured with regard to handling line endings, and core.autocrlf is set to "true" on my site, but still it did not work and I did not know how to fix that in the settings. So I made the comparison lenient with respect to additional CR character. This is a separate commit, if you don't like it just omit.

I'll be happy to test a SNAPSHOT version of the plugin once that's available.