### PR TITLE
Fixing that project comments were removed from the xml document root

### DIFF
--- a/sorter/src/main/java/sortpom/XmlProcessor.java
+++ b/sorter/src/main/java/sortpom/XmlProcessor.java
@@ -50,7 +50,23 @@ public class XmlProcessor {
     rootWrapper.sortStructureElements();
     rootWrapper.connectXmlStructure();
 
-    newDocument.setRootElement(rootWrapper.getElementContent().getContent());
+    replaceRootElementInNewDocument(rootWrapper.getElementContent().getContent());
+  }
+
+  /** Setting root element directly on the document will clear other content */
+  private void replaceRootElementInNewDocument(Element newElement) {
+    var rootElement = newDocument.getRootElement();
+    var content = newDocument.content();
+
+    newDocument.clearContent();
+
+    for (var node : content) {
+      if (node == rootElement) {
+        newDocument.add(newElement);
+      } else {
+        newDocument.add(node);
+      }
+    }
   }
 
   public Document getNewDocument() {

--- a/sorter/src/test/resources/MultilineComment_expected.xml
+++ b/sorter/src/test/resources/MultilineComment_expected.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    base-parent 
+    Copyright 
+    All rights reserved. 
+    Contributors:
+        Björn
+-->
+<?processing start?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <!-- The Basics
 		This is a multiline komment-->
   <groupId>sortpom</groupId>
   <artifactId>sortpom</artifactId>
 </project>
+<!-- End comment -->
+<?processing end?>

--- a/sorter/src/test/resources/MultilineComment_input.xml
+++ b/sorter/src/test/resources/MultilineComment_input.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    base-parent 
+    Copyright 
+    All rights reserved. 
+    Contributors:
+        Björn
+-->
+<?processing start?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <artifactId>sortpom</artifactId>
   <!-- The Basics
 		This is a multiline komment-->
   <groupId>sortpom</groupId>
 </project>
+<!-- End comment -->
+<?processing end?>


### PR DESCRIPTION
Setting Document.setRootElement will clear other content besides the actual root element. 
Loop through content and just replace the root instead.