### PR TITLE
Fix formatting if text and tags are placed together in a xml tag

### DIFF
--- a/sorter/src/test/resources/MultilineContent_expected.xml
+++ b/sorter/src/test/resources/MultilineContent_expected.xml
@@ -2,6 +2,42 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <groupId>sortpom</groupId>
   <artifactId>sortpom</artifactId>
+  <properties>
+    <argLine>
+      --XX:Something
+      <!-- disabling -->
+      -XX:TieredStopAtLevel=1
+      <!-- memory usage. -->
+      -Xmx512m
+      <!-- file encoding. -->
+      -Dfile.encoding=${project.build.sourceEncoding}
+    </argLine>
+    <argLine2>
+      <!-- disabling -->
+      -XX:TieredStopAtLevel=1
+      <!-- memory usage. -->
+      -Xmx512m
+      <!-- file encoding. -->
+    </argLine2>
+    <argLine3>
+      <tag></tag>
+      text
+      <tag></tag>
+    </argLine3>
+    <argLine4>
+      text
+      <tag></tag>
+      text
+    </argLine4>
+    <argLine5>
+      text
+      <tag></tag>
+    </argLine5>
+    <argLine6>
+      <tag></tag>
+      text
+    </argLine6>
+  </properties>
   <build>
     <plugins>
       <plugin>

--- a/sorter/src/test/resources/MultilineContent_input.xml
+++ b/sorter/src/test/resources/MultilineContent_input.xml
@@ -2,6 +2,42 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <artifactId>sortpom</artifactId>
   <groupId>sortpom</groupId>
+      <properties>
+        <argLine>
+            --XX:Something
+            <!-- disabling -->
+            -XX:TieredStopAtLevel=1
+            <!-- memory usage. -->
+            -Xmx512m
+            <!-- file encoding. -->
+            -Dfile.encoding=${project.build.sourceEncoding}
+        </argLine>
+        <argLine2>
+            <!-- disabling -->
+            -XX:TieredStopAtLevel=1
+            <!-- memory usage. -->
+            -Xmx512m
+            <!-- file encoding. -->
+        </argLine2>
+        <argLine3>
+          <tag/>
+          text
+          <tag/>
+        </argLine3>
+        <argLine4>
+          text
+          <tag/>
+          text
+        </argLine4>
+        <argLine5>
+          text
+          <tag/>
+        </argLine5>
+        <argLine6>
+          <tag/>
+          text
+        </argLine6>
+      </properties>
   <build>
     <plugins>
             <plugin>


### PR DESCRIPTION
If the text node has other content next to it (siblings) then place text on own line.

Also, unrelated optimized writeEmptyElementClose