### PR TITLE
Fix "Boot Manifest-JAR contains absolute paths in classpath" error on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -505,6 +505,17 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os>
+          <family>Windows</family>
+        </os>
+      </activation>
+      <properties>
+        <surefire.useSystemClassLoader>false</surefire.useSystemClassLoader>
+      </properties>
+    </profile>
   </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>2.0.13</slf4j.version>
+    <surefire.useManifestOnlyJar>false</surefire.useManifestOnlyJar>
   </properties>
 
   <dependencyManagement>
@@ -504,17 +505,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>windows</id>
-      <activation>
-        <os>
-          <family>Windows</family>
-        </os>
-      </activation>
-      <properties>
-        <surefire.useSystemClassLoader>false</surefire.useSystemClassLoader>
-      </properties>
     </profile>
   </profiles>
 


### PR DESCRIPTION
On Windows, if the Git repo and Maven local repo are on different drives such as E: and C: respectively, then there are errors from the Surefire plugin. This PR addresses that, if you're interested.

E:\\...\sortpom\maven-plugin\target\surefire-reports\2024-04-13T11-42-35_408.dumpstream:
```
# Created at 2024-04-13T11:42:58.124
Boot Manifest-JAR contains absolute paths in classpath 'E:\...\sortpom\maven-plugin\target\test-classes'
Hint: <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
'other' has different root
```

E:\\...\sortpom\sorter\target\surefire-reports\2024-04-13T11-42-35_408.dumpstream:
```
# Created at 2024-04-13T11:42:35.560
Boot Manifest-JAR contains absolute paths in classpath 'E:\...\sortpom\sorter\target\test-classes'
Hint: <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
'other' has different root
```

Note that the error messages are right but the hinted argLine does not help.
