### PR TITLE
Fix dynamic agent warning on JDK 21

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -35,6 +35,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <!-- Disables annotation processing since it is not needed for the plugin.
+             The 'maven-plugin-api' dependency contains a bunch of old annotation processors
+             that causes compiler warnings otherwise -->
+            <arg>-proc:none</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.github.ekryd.echo-maven-plugin</groupId>
         <artifactId>echo-maven-plugin</artifactId>
         <inherited>false</inherited>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
   </modules>
 
   <properties>
+    <argLine>-Djdk.attach.allowAttachSelf=true -XX:+EnableDynamicAgentLoading</argLine>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>2.0.13</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   </modules>
 
   <properties>
-    <argLine>-Djdk.attach.allowAttachSelf=true -XX:+EnableDynamicAgentLoading</argLine>
+    <argLine>-XX:+EnableDynamicAgentLoading</argLine>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>2.0.13</slf4j.version>


### PR DESCRIPTION
How to get ahead of dynamic agent loading errors on JDK 22+ by addressing the warnings from JDK 21.

JDK 21 Mac
```
WARNING: A Java agent has been loaded dynamically (/Users/runner/.m2/repository/net/bytebuddy/byte-buddy-agent/1.14.12/byte-buddy-agent-1.14.12.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```

This is done by explicitly enabling jvm option EnableDynamicAgentLoading.

Also, Disables annotation processing in the maven-plugin since it is not needed for the plugin, it just causes warning messages.

Thanks @mches for the contribution!!