### PR TITLE
Preserve 3.3.x method signature

### DIFF
--- a/sorter/src/main/java/sortpom/parameter/PluginParameters.java
+++ b/sorter/src/main/java/sortpom/parameter/PluginParameters.java
@@ -147,6 +147,25 @@ public class PluginParameters {
       return this;
     }
 
+    /**
+     * Sets formatting information that is used when the pom file is sorted
+     *
+     * @deprecated Use {@link #setFormatting(String, boolean, boolean, boolean, boolean)}
+     */
+    @Deprecated(forRemoval = true)
+    public Builder setFormatting(
+        final String lineSeparator,
+        final boolean expandEmptyElements,
+        final boolean spaceBeforeCloseEmptyElement,
+        final boolean keepBlankLines) {
+      return setFormatting(
+          lineSeparator,
+          expandEmptyElements,
+          spaceBeforeCloseEmptyElement,
+          keepBlankLines,
+          true);
+    }
+
     /** Sets formatting information that is used when the pom file is sorted */
     public Builder setFormatting(
         final String lineSeparator,

--- a/sorter/src/test/java/sortpom/sort/EndWithNewlineTest.java
+++ b/sorter/src/test/java/sortpom/sort/EndWithNewlineTest.java
@@ -1,7 +1,11 @@
 package sortpom.sort;
 
 import org.junit.jupiter.api.Test;
+import sortpom.parameter.PluginParameters;
 import sortpom.util.XmlProcessorTestUtil;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 class EndWithNewlineTest {
   @Test
@@ -12,5 +16,14 @@ class EndWithNewlineTest {
         .testInputAndExpected(
             "src/test/resources/Real1_input.xml",
             "src/test/resources/Real1_expected_noFinalEndline.xml");
+  }
+
+  @Test
+  @SuppressWarnings("removal")
+  void endWithNewlineShouldDefaultToTrue() {
+    PluginParameters pluginParameters = PluginParameters.builder()
+        .setFormatting(System.lineSeparator(), true, false, true)
+        .build();
+    assertThat(pluginParameters.endWithNewline, is(true));
   }
 }


### PR DESCRIPTION
Restores a 3.3.x method signature to preserve compatibility with the current version of Spotless